### PR TITLE
Change to lower case for *nix builds.

### DIFF
--- a/src/rocketpool/tokens/reth.ts
+++ b/src/rocketpool/tokens/reth.ts
@@ -5,7 +5,7 @@ import { Tx } from 'web3/eth/types';
 import { TransactionReceipt } from 'web3/types';
 import Contracts from '../contracts/contracts';
 import { ConfirmationHandler, handleConfirmations } from '../../utils/transaction';
-import ERC20 from './ERC20';
+import ERC20 from './erc20';
 
 
 /**

--- a/src/rocketpool/tokens/rpl.ts
+++ b/src/rocketpool/tokens/rpl.ts
@@ -1,7 +1,7 @@
 // Imports
 import Web3 from 'web3';
 import Contracts from '../contracts/contracts';
-import ERC20 from './ERC20';
+import ERC20 from './erc20';
 
 
 /**


### PR DESCRIPTION
Addresses following error (on Linux machines):

```
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
src/rocketpool/tokens/reth.ts:8:19 - error TS2307: Cannot find module './ERC20'.

8 import ERC20 from './ERC20';
                    ~~~~~~~~~
src/rocketpool/tokens/reth.ts:30:21 - error TS2339: Property 'tokenContract' does not exist on type 'RETH'.

30         return this.tokenContract.then((tokenContract: Contract): Promise<TransactionReceipt> => {
                       ~~~~~~~~~~~~~
```
